### PR TITLE
Add JSON mode setting for server

### DIFF
--- a/natsio_server.html
+++ b/natsio_server.html
@@ -5,7 +5,7 @@
       name: {value:''},
       host: {value:'localhost',required:true},
       port: {value:4222,required:true,validate:RED.validators.number()},
-      json: {value:true,type:'checkbox'}
+      json: {value:true}
     },
     credentials: {
       username: {type: "text"},
@@ -65,7 +65,7 @@
         <label for="node-config-input-json">
           <i class="icon-bookmark"></i> JSON mode
         </label>
-        <input type="text" id="node-config-input-json">
+        <input type="checkbox" id="node-config-input-json">
       </div>
     </div>
     <div id="natsio-server-tab-security" style="display:none">

--- a/natsio_server.html
+++ b/natsio_server.html
@@ -5,6 +5,7 @@
       name: {value:''},
       host: {value:'localhost',required:true},
       port: {value:4222,required:true,validate:RED.validators.number()},
+      json: {value:true,type:'checkbox'}
     },
     credentials: {
       username: {type: "text"},
@@ -59,6 +60,12 @@
           <i class="icon-bookmark"></i> Port
         </label>
         <input type="text" id="node-config-input-port">
+      </div>
+      <div class="form-row">
+        <label for="node-config-input-json">
+          <i class="icon-bookmark"></i> JSON mode
+        </label>
+        <input type="text" id="node-config-input-json">
       </div>
     </div>
     <div id="natsio-server-tab-security" style="display:none">

--- a/natsio_server.js
+++ b/natsio_server.js
@@ -17,7 +17,8 @@ module.exports = function(RED) {
     node.nc = nats.connect({
       'servers': [server],
       'maxReconnectAttempts': -1,
-      'reconnectTimeWait': 250
+      'reconnectTimeWait': 250,
+      'json': n.json
     });
 
     node.nc.on('error', (e) => {


### PR DESCRIPTION
This PR adds a checkbox toggle to enable / disable JSON mode for NATS. This simplifies passing JSON data from / to NATS. Otherwise JSON data needs to be „stringified“ and parsed for every request.